### PR TITLE
Windows では HOME 環境変数を取得できないため、 os.UserHomeDir に置き換える

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ run-test-%: %_test.go
 
 all-test: $(TEST_NAMES)
 
+.PHONY: test
+test: all-test
+
 ####################################
 # OS ARCH 別タスク
 

--- a/cache.go
+++ b/cache.go
@@ -54,7 +54,7 @@ func (cache *Cache) Execute(config UiShigConfig, voices []Voice) error {
 	urls := make([]VoiceURL, 0)
 	if cache.TargetIds == nil || len(cache.TargetIds) == 0 {
 		for _, voice := range voices {
-			url := uiShigConfig.ResolvePath(voice)
+			url := config.ResolvePath(voice)
 			urls = append(urls, url)
 		}
 	} else {

--- a/main.go
+++ b/main.go
@@ -15,6 +15,10 @@ var (
 )
 
 func main() {
+	uiShigConfig, err := newUiShigConfig()
+	if err != nil {
+		log.Fatalf("user home directory error: %v\n", err)
+	}
 	voices, err := ReadVoices()
 	if err != nil {
 		log.Fatalf("error: %v\n", err)
@@ -26,7 +30,7 @@ func main() {
 	}
 	commands := make([]*cli.Command, len(userOrders))
 	for i, order := range userOrders {
-		commands[i] = order.toCLICommand(uiShigConfig, voices)
+		commands[i] = order.toCLICommand(*uiShigConfig, voices)
 	}
 	app := &cli.App{
 		Name:        "しぐれういCLI",
@@ -48,9 +52,16 @@ func main() {
 	}
 }
 
-var uiShigConfig = UiShigConfig{
-	UiShigURL:      DefaultUiShigURL,
-	UiShigCacheDir: path.Join(os.Getenv("HOME"), DefaultDirectoryName, DefaultCacheDirectoryName),
+func newUiShigConfig() (*UiShigConfig, error) {
+	homeDirectory, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	var uiShigConfig = UiShigConfig{
+		UiShigURL:      DefaultUiShigURL,
+		UiShigCacheDir: path.Join(homeDirectory, DefaultDirectoryName, DefaultCacheDirectoryName),
+	}
+	return &uiShigConfig, nil
 }
 
 //goland:noinspection HttpUrlsUsage

--- a/main.go
+++ b/main.go
@@ -45,7 +45,12 @@ func main() {
   ビルド番号: %s
   ビルド日時: %s
 
-`, cli.AppHelpTemplate, UiShigVersion, UiShigCommit, UiShigBuildDate)
+------
+お困りの際はこちらから質問・不具合報告をしてください。
+
+  GitHub: %s
+
+`, cli.AppHelpTemplate, UiShigVersion, UiShigCommit, UiShigBuildDate, DefaultIssueURL)
 	err = app.Run(os.Args)
 	if err != nil {
 		log.Fatalf("error: %v\n", err)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,15 @@
+package main
+
+import "testing"
+
+func TestNewUiShigConfig(t *testing.T) {
+	config, err := newUiShigConfig()
+	if err != nil {
+		t.Fatalf("newUiShigConfig() failed: %v", err)
+		return
+	}
+	if config == nil {
+		t.Fatalf("newUiShigConfig() returned nil config")
+		return
+	}
+}


### PR DESCRIPTION
Fix #1

変更
---

- 以前の実装では、キャッシュディレクトリーを取得するために `os.Getenv("HOME")` を利用していた
- 新しい実装では、 `os.UserHomeDir()` の使用に置き換えた
- これにより、 Windows ユーザーのキャッシュディレクトリーが問題ない場所に移動するようになる

