### PR TITLE
キャッシュディレクトリー名を取り出す際に path.Split ではなく filepath.Split を使うようにしました

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         # language=bash
         run: |
           if grep -q 'FAIL' result.txt; then
-            echo "Test Failed" >> /dev/stderr
-            cat result.txt >> /dev/stderr
+            echo "Test Failed"
+            cat result.txt
             exit 1
           fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,11 +68,26 @@ jobs:
           path: tests
 
       - name: Run tests
-        shell: bash
-        run: find tests -type f -perm 0755 -print -exec {} \; 2>&1 | tee result.txt
         continue-on-error: true
+        shell: bash
+        # language=bash
+        run: |
+          find tests -type f -perm 0755 \
+            -print \
+            -exec {} \; 2>&1 | \
+          tee --append result.txt
 
       - name: Remove artifacts
         uses: geekyeggo/delete-artifact@v5
         with:
           name: all-tests
+
+      - name: Result
+        shell: bash
+        # language=bash
+        run: |
+          if grep -q 'FAIL' result.txt; then
+            echo "Test Failed" >> /dev/stderr
+            cat result.txt >> /dev/stderr
+            exit 1
+          fi

--- a/voice.go
+++ b/voice.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const PreDownloadedVoiceID = "illust"
@@ -102,6 +103,9 @@ func (vu VoiceURL) Load() ([]byte, bool, error) {
 
 func (vu VoiceURL) GetCacheDir() string {
 	parentDirectory, _ := filepath.Split(vu.File)
+	if strings.HasSuffix(parentDirectory, string(os.PathSeparator)) {
+		parentDirectory = parentDirectory[:len(parentDirectory)-1]
+	}
 	return parentDirectory
 }
 

--- a/voice.go
+++ b/voice.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 )
 
 const PreDownloadedVoiceID = "illust"
@@ -101,7 +101,7 @@ func (vu VoiceURL) Load() ([]byte, bool, error) {
 }
 
 func (vu VoiceURL) GetCacheDir() string {
-	parentDirectory, _ := path.Split(vu.File)
+	parentDirectory, _ := filepath.Split(vu.File)
 	return parentDirectory
 }
 

--- a/voice.go
+++ b/voice.go
@@ -80,7 +80,7 @@ func (vu VoiceURL) Load() ([]byte, bool, error) {
 	if err != nil {
 		return nil, false, fmt.Errorf("しぐれういボタンのデータが読み取れませんでした。 [%s] %w", vu.ID, err)
 	}
-	parentDirectory, _ := path.Split(vu.File)
+	parentDirectory := vu.GetCacheDir()
 	stat, err := os.Stat(parentDirectory)
 	if err != nil && os.IsNotExist(err) {
 		if err := os.MkdirAll(parentDirectory, 0755); err != nil {
@@ -98,6 +98,11 @@ func (vu VoiceURL) Load() ([]byte, bool, error) {
 		return nil, false, fmt.Errorf("しぐれういボタンを保存できませんでした。 [%s] %w", vu.ID, err)
 	}
 	return allBytes, true, nil
+}
+
+func (vu VoiceURL) GetCacheDir() string {
+	parentDirectory, _ := path.Split(vu.File)
+	return parentDirectory
 }
 
 func (vu VoiceURL) Delete() error {

--- a/voice_test.go
+++ b/voice_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"runtime"
+	"testing"
+)
+
+func TestVoiceURL_GetCacheDir(t *testing.T) {
+	type testData struct {
+		isWindows        bool
+		expectedCacheDir string
+		VoiceURL
+	}
+	data := []testData{
+		{
+			isWindows:        true,
+			expectedCacheDir: "C:\\Users\\test\\.ui_shig\\cache\\sound",
+			VoiceURL: VoiceURL{
+				File: "C:\\Users\\test\\.ui_shig\\cache\\sound\\test.mp3",
+			},
+		},
+		{
+			isWindows:        false,
+			expectedCacheDir: "/Users/test/.ui_shig/cache/sound",
+			VoiceURL: VoiceURL{
+				File: "/Users/test/.ui_shig/cache/sound/test.mp3",
+			},
+		},
+	}
+	for _, d := range data {
+		if (runtime.GOOS == "windows") && d.isWindows {
+			t.Run(fmt.Sprintf("GetCacheDir-windows[file=%s]", d.File), func(t *testing.T) {
+				dir := d.GetCacheDir()
+				assert.Equal(t, d.expectedCacheDir, dir)
+			})
+		}
+	}
+}

--- a/voice_test.go
+++ b/voice_test.go
@@ -3,38 +3,62 @@ package main
 import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 )
 
 func TestVoiceURL_GetCacheDir(t *testing.T) {
-	type testData struct {
-		isWindows        bool
-		expectedCacheDir string
-		VoiceURL
-	}
-	data := []testData{
-		{
-			isWindows:        true,
-			expectedCacheDir: "C:\\Users\\test\\.ui_shig\\cache\\sound",
-			VoiceURL: VoiceURL{
-				File: "C:\\Users\\test\\.ui_shig\\cache\\sound\\test.mp3",
-			},
-		},
-		{
-			isWindows:        false,
-			expectedCacheDir: "/Users/test/.ui_shig/cache/sound",
-			VoiceURL: VoiceURL{
-				File: "/Users/test/.ui_shig/cache/sound/test.mp3",
-			},
-		},
-	}
-	for _, d := range data {
-		if (runtime.GOOS == "windows") && d.isWindows {
-			t.Run(fmt.Sprintf("GetCacheDir-windows[file=%s]", d.File), func(t *testing.T) {
-				dir := d.GetCacheDir()
-				assert.Equal(t, d.expectedCacheDir, dir)
-			})
+	t.Run("DirectoryName Matches ExpectedName", func(t *testing.T) {
+		type testData struct {
+			isWindows        bool
+			expectedCacheDir string
+			VoiceURL
 		}
-	}
+		data := []testData{
+			{
+				isWindows:        true,
+				expectedCacheDir: "C:\\Users\\test\\.ui_shig\\cache\\sound",
+				VoiceURL: VoiceURL{
+					File: "C:\\Users\\test\\.ui_shig\\cache\\sound\\test.mp3",
+				},
+			},
+			{
+				isWindows:        false,
+				expectedCacheDir: "/Users/test/.ui_shig/cache/sound",
+				VoiceURL: VoiceURL{
+					File: "/Users/test/.ui_shig/cache/sound/test.mp3",
+				},
+			},
+		}
+		for _, d := range data {
+			if (runtime.GOOS == "windows") && d.isWindows {
+				t.Run(fmt.Sprintf("GetCacheDir-windows[file=%s]", d.File), func(t *testing.T) {
+					dir := d.GetCacheDir()
+					assert.Equal(t, d.expectedCacheDir, dir)
+				})
+			}
+		}
+	})
+
+	t.Run("DirectoryName Is Valid", func(t *testing.T) {
+		tempDir, err := os.MkdirTemp("", "voice-url-test*cache")
+		if err != nil {
+			t.Fatal("Failed to create temp dir", err)
+			return
+		}
+		//goland:noinspection GoUnhandledErrorResult
+		defer os.RemoveAll(tempDir)
+
+		path := filepath.Join(tempDir, "test.mp3")
+		voiceURL := VoiceURL{File: path}
+
+		err = voiceURL.CreateCacheDirIfNotExists()
+
+		assert.Nil(t, err)
+
+		cacheDir := voiceURL.GetCacheDir()
+		assert.DirExists(t, cacheDir)
+	})
 }

--- a/voice_test.go
+++ b/voice_test.go
@@ -43,7 +43,7 @@ func TestVoiceURL_GetCacheDir(t *testing.T) {
 	})
 
 	t.Run("DirectoryName Is Valid", func(t *testing.T) {
-		tempDir, err := os.MkdirTemp("", "voice-url-test*cache")
+		tempDir, err := os.MkdirTemp("", "voice-url-test*user")
 		if err != nil {
 			t.Fatal("Failed to create temp dir", err)
 			return
@@ -51,14 +51,28 @@ func TestVoiceURL_GetCacheDir(t *testing.T) {
 		//goland:noinspection GoUnhandledErrorResult
 		defer os.RemoveAll(tempDir)
 
-		path := filepath.Join(tempDir, "test.mp3")
+		path := filepath.Join(tempDir, ".ui_shig", "cache", "sound", "test.mp3")
 		voiceURL := VoiceURL{File: path}
 
 		err = voiceURL.CreateCacheDirIfNotExists()
 
-		assert.Nil(t, err)
+		if !assert.Nil(t, err) {
+			return
+		}
 
 		cacheDir := voiceURL.GetCacheDir()
-		assert.DirExists(t, cacheDir)
+		if !assert.DirExists(t, cacheDir) {
+			return
+		}
+
+		f, err := os.Create(path)
+		if err != nil {
+			t.Fatal("Failed to open file", err)
+			return
+		}
+		//goland:noinspection GoUnhandledErrorResult
+		defer f.Close()
+		_, err = f.Write([]byte("test"))
+		assert.Nilf(t, err, "failed to write to file: %v\n", err)
 	})
 }


### PR DESCRIPTION
Fix #1

変更概要
---

- キャッシュディレクトリー名を取り出す際に path.Split ではなく filepath.Split を使うようにしました
- `path.Split` では windows のパス名を正しく扱えず、ディレクトリーが作成できていませんでした

